### PR TITLE
23 scrape awards

### DIFF
--- a/SentralTimetable/objects.py
+++ b/SentralTimetable/objects.py
@@ -131,26 +131,28 @@ class Award:
     """A class to manage an award"""
 
     def __init__(self, date: Date, type_: str, reason: str, teacher: str,
-                 for_: str = "", via: str = ""):
+                 value: int, for_: str = "", via: str = ""):
         self.date = date
         self.type = type_
         self.reason = reason
         self.teacher = teacher
+        self.value = value
         self.for_ = for_
         self.via = via
 
     def __str__(self):
         if self.for_ != "" and self.via != "":
             return f"{self.type} on {self.date} for {self.for_} via " \
-                   f"{self.via} ({self.reason})"
+                   f"{self.via} ({self.reason}, {self.value} points)"
         elif self.for_ != "":
             return f"{self.type} on {self.date} for {self.for_} " \
-                   f"({self.reason})"
+                   f"({self.reason}, {self.value} points)"
         elif self.via != "":
             return f"{self.type} on {self.date} via {self.via} " \
-                   f"({self.reason})"
+                   f"({self.reason}, {self.value} points)"
         else:
-            return f"{self.type} on {self.date} ({self.reason})"
+            return f"{self.type} on {self.date} ({self.reason}, {self.value} " \
+                   f"points)"
 
     def __repr__(self):
         return f"Award({self.date}, {self.type}, {self.reason}, " \

--- a/SentralTimetable/objects.py
+++ b/SentralTimetable/objects.py
@@ -215,16 +215,18 @@ class Sentral:
     """One class to rule them all... or at least contain the others"""
 
     def __init__(self, classes: list[Period or EmptyPeriod],
-                 notices: list[Notice], events: list[Event], user: User):
+                 notices: list[Notice], events: list[Event],
+                 awards: list[Award], user: User):
         self.classes = classes
         self.notices = notices
         self.events = events
+        self.awards = awards
         self.user = user
 
     def __str__(self):
         return f"Sentral({self.classes}, {self.notices}, {self.events}, " \
-               f"{self.user})"
+               f"{self.awards}, {self.user})"
 
     def __repr__(self):
         return f"Sentral({self.classes}, {self.notices}, {self.events}, " \
-               f"{self.user})"
+               f"{self.awards}, {self.user})"

--- a/SentralTimetable/objects.py
+++ b/SentralTimetable/objects.py
@@ -127,6 +127,36 @@ class DateRange:
                f"{self.end_minute})"
 
 
+class Award:
+    """A class to manage an award"""
+
+    def __init__(self, date: Date, type_: str, reason: str, teacher: str,
+                 for_: str = "", via: str = ""):
+        self.date = date
+        self.type = type_
+        self.reason = reason
+        self.teacher = teacher
+        self.for_ = for_
+        self.via = via
+
+    def __str__(self):
+        if self.for_ != "" and self.via != "":
+            return f"{self.type} on {self.date} for {self.for_} via " \
+                   f"{self.via} ({self.reason})"
+        elif self.for_ != "":
+            return f"{self.type} on {self.date} for {self.for_} " \
+                   f"({self.reason})"
+        elif self.via != "":
+            return f"{self.type} on {self.date} via {self.via} " \
+                   f"({self.reason})"
+        else:
+            return f"{self.type} on {self.date} ({self.reason})"
+
+    def __repr__(self):
+        return f"Award({self.date}, {self.type}, {self.reason}, " \
+               f"{self.teacher}, {self.for_}, {self.via})"
+
+
 class Notice:
     """A class to manage a notice."""
 

--- a/SentralTimetable/objects.py
+++ b/SentralTimetable/objects.py
@@ -141,18 +141,21 @@ class Award:
         self.via = via
 
     def __str__(self):
-        if self.for_ != "" and self.via != "":
-            return f"{self.type} on {self.date} for {self.for_} via " \
-                   f"{self.via} ({self.reason}, {self.value} points)"
-        elif self.for_ != "":
-            return f"{self.type} on {self.date} for {self.for_} " \
-                   f"({self.reason}, {self.value} points)"
-        elif self.via != "":
-            return f"{self.type} on {self.date} via {self.via} " \
-                   f"({self.reason}, {self.value} points)"
+        if self.via != "":
+            via = f" via {self.via}"
         else:
-            return f"{self.type} on {self.date} ({self.reason}, {self.value} " \
-                   f"points)"
+            via = ""
+        if self.for_ != "":
+            for_ = f" for {self.for_}"
+        else:
+            for_ = ""
+        if self.teacher != "":
+            teacher = f" from {self.teacher}"
+        else:
+            teacher = ""
+        return f"{self.date} - {self.type}: {self.reason}{for_}{via}{teacher}"\
+                 f" ({self.value} points)"
+
 
     def __repr__(self):
         return f"Award({self.date}, {self.type}, {self.reason}, " \

--- a/SentralTimetable/scrapers.py
+++ b/SentralTimetable/scrapers.py
@@ -300,3 +300,86 @@ def scrape_calendar(html: str) -> list:
                 event_type
             ))
     return data
+
+def scrape_awards(html: str) -> list:
+    """
+    Scrape the HTML for the awards
+    :param html: The HTML source code
+    :return: The awards
+    """
+    # Fetch the page and create a BeautifulSoup object
+    soup = BeautifulSoup(html, 'html.parser')
+    data = []
+    awards_table = soup.find_all(
+        'table',
+        class_='table table-striped table-hover'
+    )[1].find('tbody')
+    awards = awards_table.find_all('tr')
+    for award in awards:
+        award_date_tuple = BeautifulSoup(
+            str(award).split('<br/>')[0],
+            'html.parser'
+        ).find_all('td')[0].text.split()[0].split('/')
+        try:
+            award_date = Date(
+                int(award_date_tuple[2]),
+                int(award_date_tuple[1]),
+                int(award_date_tuple[0])
+            )
+        except ValueError:
+            award_date = Date(0, 1, 1)
+        award_type = award.find_all('td')[1].find('strong').text.rstrip(':')\
+            .replace('&#039;', "'")
+        award_reason = BeautifulSoup(
+            str(award.find_all('td')[1]).split('<br/>')[0].split('</strong>')
+            [1],
+            'html.parser'
+        ).text.strip()
+        try:
+            other_text = ''.join(
+                str(award.find_all('td')[1]).split('<br/>')[1:]
+            ).split('</td>')[0]  # The text that will include any/some/all of
+            # the following:
+            # - 'for'
+            # - 'via'
+            # - 'by'
+        except IndexError:  # There is no other text
+            other_text = ''
+        if other_text.find('for') != -1:
+            award_for = BeautifulSoup(
+                other_text.split('for')[1],
+                'html.parser'
+            ).find('span').text.strip()
+        else:
+            award_for = ''
+        if other_text.find('via') != -1:
+            award_via = BeautifulSoup(
+                other_text.split('via')[1],
+                'html.parser'
+            ).find('a').text.strip()
+        else:
+            award_via = ''
+        if other_text.find('by') != -1:
+            award_teacher = BeautifulSoup(
+                other_text.split('by')[1],
+                'html.parser'
+            ).find('span').text.strip()
+        else:
+            award_teacher = ''
+
+        try:
+            award_value = int(award.find_all('td')[2].text.strip())
+        except ValueError:
+            award_value = 0
+
+        data.append(Award(
+            award_date,
+            award_type,
+            award_reason,
+            award_teacher,
+            award_value,
+            award_for,
+            award_via
+        ))
+
+    return data

--- a/SentralTimetable/timetable.py
+++ b/SentralTimetable/timetable.py
@@ -97,8 +97,9 @@ def get_timetable(usr: str = None, pwd: str = None, url: str = None,
     __return_to_homepage(driver, url, debug, timeout)
     if debug:
         print("Navigating to and scraping awards")
+    awards = []
     for _ in webdriver_get_awards_pages(driver, timeout):
-        print(driver.current_url)
+        awards.extend(scrape_awards(driver.page_source))
 
     return Sentral(
         classes=classes,

--- a/SentralTimetable/timetable.py
+++ b/SentralTimetable/timetable.py
@@ -52,6 +52,25 @@ def __login_to_homepage(usr: str = None, pwd: str = None, url: str = None,
     return driver, debug, usr, pwd, url, timeout
 
 
+def __return_to_homepage(driver, url, debug, timeout):
+    """Return to the homepage"""
+    if debug:
+        print("Navigating to homepage")
+    driver.get(url)
+
+    while True:
+        if driver.current_url.endswith('/portal/dashboard'):
+            return
+        elif time.time() > start_time + timeout:
+            raise TypeError(
+                "The URL is not at the specified Sentral dashboard.\n "
+                "Please disable headless mode and test the code to ensure "
+                "that it is functional. The page may also have failed to "
+                "load in 5 secs. You can change the timeout by passing a "
+                "value to the timeout arguement"
+            )
+
+
 def get_timetable(usr: str = None, pwd: str = None, url: str = None,
                   debug: bool = None, timeout: int = None) -> Sentral:
     """Get the timetable for the current week"""
@@ -72,6 +91,14 @@ def get_timetable(usr: str = None, pwd: str = None, url: str = None,
     if debug:
         print("Scraping Calendar")
     events = scrape_calendar(driver.page_source)
+
+    if debug:
+        print("Navigating home")
+    __return_to_homepage(driver, url, debug, timeout)
+    if debug:
+        print("Navigating to and scraping awards")
+    for _ in webdriver_get_awards_pages(driver, timeout):
+        print(driver.current_url)
 
     return Sentral(
         classes=classes,

--- a/SentralTimetable/timetable.py
+++ b/SentralTimetable/timetable.py
@@ -105,6 +105,7 @@ def get_timetable(usr: str = None, pwd: str = None, url: str = None,
         classes=classes,
         notices=notices,
         events=events,
+        awards=awards,
         user=user
     )
 

--- a/SentralTimetable/webdriver.py
+++ b/SentralTimetable/webdriver.py
@@ -101,7 +101,6 @@ def webdriver_get_awards_pages(driver: webdriver.Chrome, timeout: int = 5) -> \
                 "value to the timeout arguement"
             )
     # Loop through the pages
-    old_url = driver.current_url
 
     while True:
         yield None

--- a/SentralTimetable/webdriver.py
+++ b/SentralTimetable/webdriver.py
@@ -1,5 +1,6 @@
 """Functions to simplify use of the webdriver"""
 # Standard library imports
+from typing import Generator  # Type 'Generator' needs to be imported
 import time
 
 # Third party imports
@@ -54,6 +55,66 @@ def webdriver_login(driver: webdriver.Chrome, usr: str, pwd: str, url: str,
         while True:
             if driver.current_url.endswith('/portal/dashboard'):
                 return
+            elif time.time() > start_time + timeout:
+                raise TypeError(
+                    "The URL is not at the specified Sentral dashboard.\n "
+                    "Please disable headless mode and test the code to ensure "
+                    "that it is functional. The page may also have failed to "
+                    "load in 5 secs. You can change the timeout by passing a "
+                    "value to the timeout arguement"
+                )
+
+
+def webdriver_get_awards_pages(driver: webdriver.Chrome, timeout: int = 5) -> \
+        Generator:
+    """Get the pages of the awards section of Sentral."""
+    # Open the wellbeing section
+    url = driver.find_element(value='portal-links')\
+        .find_element(By.CLASS_NAME, 'colour-wellbeing').get_attribute('href')
+    driver.get(url)
+    start_time = time.time()
+    while True:
+        if '/wellbeing/overview/' in driver.current_url:
+            break
+        elif time.time() > start_time + timeout:
+            raise TypeError(
+                "The URL is not at the specified Sentral dashboard.\n "
+                "Please disable headless mode and test the code to ensure "
+                "that it is functional. The page may also have failed to "
+                "load in 5 secs. You can change the timeout by passing a "
+                "value to the timeout arguement"
+            )
+    # Open the awards section
+    url = driver.find_elements(By.CLASS_NAME, "colour-wellbeing")[3]\
+        .get_attribute('href')
+    driver.get(url)
+    start_time = time.time()
+    while True:
+        if '/wellbeing/awards' in driver.current_url:
+            break
+        elif time.time() > start_time + timeout:
+            raise TypeError(
+                "The URL is not at the specified Sentral dashboard.\n "
+                "Please disable headless mode and test the code to ensure "
+                "that it is functional. The page may also have failed to "
+                "load in 5 secs. You can change the timeout by passing a "
+                "value to the timeout arguement"
+            )
+    # Loop through the pages
+    old_url = driver.current_url
+
+    while True:
+        yield None
+        old_url = driver.current_url
+        next_url = driver.find_element(By.CLASS_NAME, "icon-chevron-left")\
+        .find_element(By.XPATH, "..").get_attribute('href')
+        if next_url == "#" or next_url == driver.current_url + "#":
+            break
+        driver.find_element(By.CLASS_NAME, "icon-chevron-left").click()
+        start_time = time.time()
+        while True:
+            if driver.current_url != old_url:
+                break
             elif time.time() > start_time + timeout:
                 raise TypeError(
                     "The URL is not at the specified Sentral dashboard.\n "

--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ class App:
         self.btn_notices = None
         self.btn_events = None
         self.btn_me = None
+        self.btn_awards = None
         self.btn_settings = None
         self.btn_reload = None
 
@@ -36,7 +37,7 @@ class App:
         
         self.window = tk.Tk()
         self.window.title("Sentral")
-        self.window.geometry("500x500")
+        self.window.geometry("600x600")
         urllib.request.urlretrieve(
             "https://github.com/J-J-B-J/get-sentral/raw/main/docs/img/icon"
             ".png", "icon.png")
@@ -54,11 +55,13 @@ class App:
             [],
             [],
             [],
+            [],
             SentralTimetable.User("", "", 0, "", "")
         )
 
         self.notice_range_start = 0
         self.event_range_start = -1
+        self.award_range_start = 0
 
         # Read the app data file to get the details
         details = dict(dotenv.dotenv_values("App_Credentials.env"))
@@ -110,6 +113,10 @@ class App:
         self.btn_me = create_button(
             "Me",
             self.me
+        )
+        self.btn_awards = create_button(
+            "Awards",
+            self.awards
         )
         self.btn_settings = create_button(
             "Settings",
@@ -713,6 +720,112 @@ class App:
             save_thread.start()
 
         btn_save.bind("<Button-1>", save_journal)
+
+    def awards(self, *_):
+        """The 'awards' page"""
+        self.destroy_section_objects()
+        self.create_title_and_set_mode("Awards", self.awards)
+
+        if not self.data.awards:
+            lbl_no_awards = tk.Label(
+                self.window,
+                text="No awards found. Try harder! ;)"
+            )
+            self.section_objects.append(lbl_no_awards)
+            lbl_no_awards.pack()
+
+        frm_awards = tk.Frame(self.window, width=500, height=450)
+        self.section_objects.append(frm_awards)
+        frm_awards.pack()
+
+        def increase_range(*_):
+            """Increase the range of awards shown"""
+            self.award_range_start += 5
+            self.awards()
+
+        def decrease_range(*_):
+            """Decrease the range of awards shown"""
+            self.award_range_start -= 5
+            self.awards()
+
+        def open_award(this_award: SentralTimetable.Award, *_):
+            """Show the detail view for an award"""
+            award_window = tk.Tk()
+            award_window.title('Award')
+            award_window.geometry('500x150')
+            award_window.focus_set()
+            award_window.bind(
+                "<Escape>",
+                lambda _: award_window.destroy()
+            )
+
+            lbl_title = tk.Label(
+                award_window,
+                text=f"{this_award.date}: {this_award.type}",
+                font=("Arial", 20)
+            )
+            lbl_title.pack(side=tk.TOP)
+
+            lbl_reason = tk.Label(
+                award_window,
+                text=f"Reason: {this_award.reason}"
+            )
+            lbl_reason.pack(side=tk.TOP)
+
+            if this_award.for_:
+                lbl_for = tk.Label(
+                    award_window,
+                    text=f"For: {this_award.for_}"
+                )
+                lbl_for.pack(side=tk.TOP)
+
+            if this_award.via:
+                lbl_via = tk.Label(
+                    award_window,
+                    text=f"Via: {this_award.via}"
+                )
+                lbl_via.pack(side=tk.TOP)
+
+            if this_award.teacher != "":
+                lbl_teacher = tk.Label(
+                    award_window,
+                    text=f"By {this_award.teacher}"
+                )
+                lbl_teacher.pack(side=tk.TOP)
+
+            lbl_value = tk.Label(
+                award_window,
+                text=f"Value: {this_award.value}"
+            )
+            lbl_value.pack(side=tk.TOP)
+
+            award_window.mainloop()
+
+        for award in self.data.awards[
+                     self.award_range_start:self.award_range_start + 5]:
+            frm_award = tk.Frame(frm_awards, width=500, height=50)
+            self.section_objects.append(frm_award)
+            frm_award.pack()
+
+            lbl_award_title = tk.Label(
+                frm_award,
+                text=f"{award.date}: {award.type}",
+                width=50,
+                height=2,
+                wraplength=390,
+                borderwidth=3,
+                relief="raised"
+            )
+            self.section_objects.append(lbl_award_title)
+            lbl_award_title.pack(side=tk.LEFT)
+            lbl_award_title.bind(
+                "<Button-1>",
+                partial(open_award, award)
+            )
+
+        self.create_increase_decrease(frm_awards, self.award_range_start, 5,
+                                      self.data.awards, increase_range,
+                                      decrease_range)
 
     def settings(self, *_):
         """The 'settings' page"""

--- a/app.py
+++ b/app.py
@@ -337,12 +337,12 @@ class App:
 
         def increase_range(*_):
             """Increase the range of notices shown"""
-            self.notice_range_start += 5
+            self.notice_range_start += 11
             self.notices()
 
         def decrease_range(*_):
             """Decrease the range of notices shown"""
-            self.notice_range_start -= 5
+            self.notice_range_start -= 11
             self.notices()
 
         def open_notice(this_notice: SentralTimetable.Notice, *_):
@@ -382,7 +382,7 @@ class App:
             notice_window.mainloop()
 
         for notice in self.data.notices[
-                      self.notice_range_start:self.notice_range_start + 5]:
+                      self.notice_range_start:self.notice_range_start + 11]:
             frm_notice = tk.Frame(frm_notices, width=500, height=50)
             self.section_objects.append(frm_notice)
             frm_notice.pack()
@@ -403,7 +403,7 @@ class App:
                 partial(open_notice, notice)
             )
         
-        self.create_increase_decrease(frm_notices, self.notice_range_start, 5,
+        self.create_increase_decrease(frm_notices, self.notice_range_start, 11,
                                       self.data.notices, increase_range,
                                       decrease_range)
 
@@ -740,12 +740,12 @@ class App:
 
         def increase_range(*_):
             """Increase the range of awards shown"""
-            self.award_range_start += 5
+            self.award_range_start += 11
             self.awards()
 
         def decrease_range(*_):
             """Decrease the range of awards shown"""
-            self.award_range_start -= 5
+            self.award_range_start -= 11
             self.awards()
 
         def open_award(this_award: SentralTimetable.Award, *_):
@@ -802,7 +802,7 @@ class App:
             award_window.mainloop()
 
         for award in self.data.awards[
-                     self.award_range_start:self.award_range_start + 5]:
+                     self.award_range_start:self.award_range_start + 11]:
             frm_award = tk.Frame(frm_awards, width=500, height=50)
             self.section_objects.append(frm_award)
             frm_award.pack()
@@ -823,7 +823,7 @@ class App:
                 partial(open_award, award)
             )
 
-        self.create_increase_decrease(frm_awards, self.award_range_start, 5,
+        self.create_increase_decrease(frm_awards, self.award_range_start, 11,
                                       self.data.awards, increase_range,
                                       decrease_range)
 

--- a/examples/Print Data.py
+++ b/examples/Print Data.py
@@ -82,6 +82,10 @@ def main():
             print(event.flag + '\033[0;0m')
         print()
 
+    print("\n\nAWARDS\n")
+    for award in timetable.awards:
+        print(str(award))
+
     print("\n\nME\n")
     print(f"Name: {timetable.user.name}")
     print(f"Number: {timetable.user.number}")


### PR DESCRIPTION
This PR adds feature #23 

I have done this by:
- Creating a new object called `Award`, with the attributes `date: Date`, `type_: str`, `reason: str`, `teacher: str`, 'value: int`, `for: str` and `via: str`
- Making a new `webdriver` function which is a `Generator`, and loops through all the awards pages (they are year-by-year)
- Making a new `scraper` function to scrape each page of awards
- Modifying the `Sentral` object to have a new attribute: `awards`
- Updating the programs `Print Data.py` and `app.py` to include awards