### PR TITLE
Added 'journal unavailable' error if journal input on dashboard cannot be found

### DIFF
--- a/SentralTimetable/scrapers.py
+++ b/SentralTimetable/scrapers.py
@@ -24,6 +24,10 @@ MONTHS_SHORT = [
     "Sep", "Oct", "Nov", "Dec"
 ]
 
+class JournalUnavailableError(Exception):
+    """The journal for today is not available"""
+    pass
+
 
 def scrape_timetable(html: str) -> list[SchoolDay]:
     """
@@ -210,9 +214,9 @@ def scrape_user(html: str) -> User:
         journal_form = soup.find_all(class_='span3')[1].find('form')
         journal_text_box = journal_form.find(class_='editable')
     except AttributeError:
-        journal = "ERR_JOURNAL_UNAVAILABLE"
+        journal = JournalUnavailableError
     except IndexError:
-        journal = "ERR_JOURNAL_UNAVAILABLE"
+        journal = JournalUnavailableError
     else:
         if journal_text_box is None:
             journal = ""

--- a/SentralTimetable/scrapers.py
+++ b/SentralTimetable/scrapers.py
@@ -162,9 +162,9 @@ def scrape_user(html: str) -> User:
         journal_form = soup.find_all(class_='span3')[1].find('form')
         journal_text_box = journal_form.find(class_='editable')
     except AttributeError:
-        journal = "Today is a weekend/holiday. You cannot access your journal."
+        journal = "ERR_JOURNAL_UNAVAILABLE"
     except IndexError:
-        journal = "Today is a weekend/holiday. You cannot access your journal."
+        journal = "ERR_JOURNAL_UNAVAILABLE"
     else:
         if journal_text_box is None:
             journal = ""

--- a/app.py
+++ b/app.py
@@ -742,9 +742,12 @@ class App:
         )
         self.section_objects.append(btn_save)
         btn_save.pack(side=tk.TOP)
-        if self.data.user.journal == "ERR_JOURNAL_UNAVAILABLE":
+
+        if self.data.user.journal == SentralTimetable.JournalUnavailableError:
             txt_journal.delete("1.0", "end")
-            txt_journal.insert("1.0", "Today is a weekend/holiday. You cannot access your journal.")
+            txt_journal.insert("1.0", "Today is a weekend/holiday. You cannot "
+                                      "access your journal.")
+
             btn_save.config(state=tk.DISABLED)
             return txt_journal.config(state=tk.DISABLED)
 

--- a/app.py
+++ b/app.py
@@ -684,6 +684,11 @@ class App:
         )
         self.section_objects.append(btn_save)
         btn_save.pack(side=tk.TOP)
+        if self.data.user.journal == "ERR_JOURNAL_UNAVAILABLE":
+            txt_journal.delete("1.0", "end")
+            txt_journal.insert("1.0", "Today is a weekend/holiday. You cannot access your journal.")
+            btn_save.config(state=tk.DISABLED)
+            return txt_journal.config(state=tk.DISABLED)
 
         def save_journal(*_):
             """Save the journal in the background"""

--- a/examples/Print Data.py
+++ b/examples/Print Data.py
@@ -1,4 +1,5 @@
 """Print out your details from Sentral"""
+import SentralTimetable
 from SentralTimetable import get_timetable, objects
 import datetime
 
@@ -88,12 +89,19 @@ def main():
             print(event.flag + '\033[0;0m')
         print()
 
+    with timetable.user.journal as journal:
+        if journal == SentralTimetable.JournalUnavailableError:
+            journal = "Today is a weekend/holiday. You cannot access your " \
+                      "journal."
+        elif journal == "":
+            journal = "You do not have a journal entry for today."
+
     print("\n\nME\n")
     print(f"Name: {timetable.user.name}")
     print(f"Number: {timetable.user.number}")
     print(f"School: {timetable.user.school}")
     print(f"\nBarcode:\n\n{timetable.user.barcode}")
-    print(f"\nJournal:\n{timetable.user.journal}")
+    print(f"\nJournal:\n{journal}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes issue #35 

I have done this by first checking if `bs4` can find and initialise the variable `journal_form` (`scrapers.py`) with the form used on the Sentral dashboard to post students' journals. If the form is unavailable, the try-except implemented will set the variable `journal` to `ERR_JOURNAL_UNAVAILABLE`. Then, when the Tkinter frames and text box are initialised, the program checks if the `journal` variable contains the error. If it does, it will disable the textbox and the submit button, and replace the text in the textbox with an error telling the user that the journal cannot be used right now, presumably because it is a holiday or weekend.

Referring to something mentioned in #35 , I didn't know how to initialise a variable part of the `SentralTimetable` object to make `SentralTimetable.JOURNAL_UNAVAILABLE`, so if @J-J-B-J you could help make it an error part of the object instead of a string error, that would be greatly appreciated :)
